### PR TITLE
fix: entity physics movement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ add_executable(metroidvania_tests
     tests/unit/inventory_tests.cpp
     tests/unit/effect_tests.cpp
     tests/unit/interaction_indicator_tests.cpp
+    tests/unit/entity_physics_tests.cpp
     ${GAME_SOURCES})
 target_include_directories(metroidvania_tests PRIVATE src)
 target_include_directories(metroidvania_tests PRIVATE src external/tileson)

--- a/src/entities/entity_physics.cpp
+++ b/src/entities/entity_physics.cpp
@@ -4,18 +4,14 @@ namespace EntityPhysics {
 
 bool isWallOnLeft(const sf::Vector2f position, const float width, const float height, const World &world)
 {
-	const float probeX = position.x - width / 2.f - 1.f;
-	const auto top = world.getTileAtCoordinate({probeX, position.y - height + 1.f}, "Solid");
-	const auto mid = world.getTileAtCoordinate({probeX, position.y - height / 2.f}, "Solid");
-	return (top || mid);
+	const sf::FloatRect probe({position.x - width / 2.f - 1.f, position.y - height + 1.f}, {1.f, height - 2.f});
+	return world.isSolidAtRect(probe);
 }
 
 bool isWallOnRight(const sf::Vector2f position, const float width, const float height, const World &world)
 {
-	const float probeX = position.x + width / 2.f + 1.f;
-	const auto top = world.getTileAtCoordinate({probeX, position.y - height + 1.f}, "Solid");
-	const auto mid = world.getTileAtCoordinate({probeX, position.y - height / 2.f}, "Solid");
-	return (top || mid);
+	const sf::FloatRect probe({position.x + width / 2.f, position.y - height + 1.f}, {1.f, height - 2.f});
+	return world.isSolidAtRect(probe);
 }
 
 bool isGroundBelow(sf::FloatRect bounds, const World &world)
@@ -27,7 +23,9 @@ bool isGroundBelow(sf::FloatRect bounds, const World &world)
 }
 void applyGravity(float &velY, bool &isOnGround, float dt, float gravity, sf::FloatRect bounds, const World &world)
 {
-	if (!isGroundBelow(bounds, world)) {
+	if (isGroundBelow(bounds, world)) {
+		isOnGround = true;
+	} else {
 		isOnGround = false;
 		velY += gravity * (double)dt;
 	}
@@ -55,10 +53,10 @@ float resolveVertical(sf::Vector2f pos, float &velY, bool &isOnGround, float wid
 {
 	float deltaY = velY * dt;
 	float futureY = pos.y + deltaY;
-	sf::FloatRect future({pos.x - width / 2.f, futureY - height}, {width, height});
+	sf::FloatRect future({pos.x - width / 2.f, futureY - height}, {width, height - 1.f});
 
 	if (world.isSolidAtRect(future)) {
-		if (deltaY > 0.f) {
+		if (deltaY >= 0.f) {
 			isOnGround = true;
 			int tileY = static_cast<int>(futureY / World::TILE_SIZE);
 			futureY = float(tileY * World::TILE_SIZE);

--- a/src/entities/player/states/wall_slide_state.cpp
+++ b/src/entities/player/states/wall_slide_state.cpp
@@ -9,6 +9,7 @@ WallSlideState::WallSlideState()
 
 void WallSlideState::onEnter(Player &p)
 {
+	p.isOnGround = false;
 	originalGravity = p.gravity;
 	p.gravity *= WALL_SLIDE_GRAVITY_FACTOR;
 	p.velocity.y *= 0.1f;
@@ -24,6 +25,9 @@ void WallSlideState::onExit(Player &p)
 
 PlayerState *WallSlideState::update(float dt, Player &p)
 {
+	if (p.isOnGround) {
+		return &p.states.landing;
+	}
 	if (p.inputJump) {
 		p.wallJumpTimer = Player::WALL_JUMP_DURATION;
 		p.velocity.x = wallDirection == Direction::Left ? Player::RUNNING_SPEED : -Player::RUNNING_SPEED;

--- a/tests/unit/entity_physics_tests.cpp
+++ b/tests/unit/entity_physics_tests.cpp
@@ -1,0 +1,258 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "entities/entity_physics.h"
+#include "world/world.h"
+#include <vector>
+
+namespace {
+
+static constexpr float T = World::TILE_SIZE;
+static constexpr float PLAYER_SIZE = 32.f;
+static constexpr float WALL_LEFT = 2 * T;
+static constexpr float WALL_TOP = 1 * T;
+static constexpr float FLOOR_TOP = 3 * T;
+
+World makeEmptyWorld()
+{
+	std::vector<std::vector<int>> grid(10, std::vector<int>(10, 0));
+	World world("test");
+	world.loadFromGrid(grid);
+	return world;
+}
+
+World makeWorldWithWallTile()
+{
+	std::vector<std::vector<int>> grid(10, std::vector<int>(10, 0));
+	grid[1][2] = 1;
+	World world("test");
+	world.loadFromGrid(grid);
+	return world;
+}
+
+World makeWorldWithFloor()
+{
+	std::vector<std::vector<int>> grid(10, std::vector<int>(10, 0));
+	for (int col = 0; col < 10; ++col)
+		grid[3][col] = 1;
+	World world("test");
+	world.loadFromGrid(grid);
+	return world;
+}
+
+} // namespace
+
+// ─── isGroundBelow ────────────────────────────────────────────────────────────
+
+TEST_CASE("isGroundBelow: detects solid tile directly below entity")
+{
+	World world = makeWorldWithFloor();
+	sf::FloatRect bounds({WALL_LEFT, FLOOR_TOP - PLAYER_SIZE}, {PLAYER_SIZE, PLAYER_SIZE});
+	REQUIRE(EntityPhysics::isGroundBelow(bounds, world));
+}
+
+TEST_CASE("isGroundBelow: returns false when no ground below")
+{
+	World world = makeEmptyWorld();
+	sf::FloatRect bounds({WALL_LEFT, FLOOR_TOP - PLAYER_SIZE}, {PLAYER_SIZE, PLAYER_SIZE});
+	REQUIRE(!EntityPhysics::isGroundBelow(bounds, world));
+}
+
+TEST_CASE("isGroundBelow: returns false when entity is far above ground")
+{
+	World world = makeWorldWithFloor();
+	sf::FloatRect bounds({WALL_LEFT, WALL_TOP}, {PLAYER_SIZE, PLAYER_SIZE});
+	REQUIRE(!EntityPhysics::isGroundBelow(bounds, world));
+}
+
+// ─── isWallOnLeft / isWallOnRight ─────────────────────────────────────────────
+
+TEST_CASE("isWallOnLeft: detects solid tile to the left")
+{
+	World world = makeWorldWithWallTile();
+	sf::Vector2f pos{WALL_LEFT + T + PLAYER_SIZE / 2.f, WALL_TOP + T / 2.f};
+	REQUIRE(EntityPhysics::isWallOnLeft(pos, PLAYER_SIZE, PLAYER_SIZE, world));
+}
+
+TEST_CASE("isWallOnLeft: returns false when nothing to the left")
+{
+	World world = makeEmptyWorld();
+	sf::Vector2f pos{5 * T, WALL_TOP + T / 2.f};
+	REQUIRE(!EntityPhysics::isWallOnLeft(pos, PLAYER_SIZE, PLAYER_SIZE, world));
+}
+
+TEST_CASE("isWallOnRight: detects solid tile to the right")
+{
+	World world = makeWorldWithWallTile();
+	sf::Vector2f pos{WALL_LEFT - PLAYER_SIZE / 2.f, WALL_TOP + T / 2.f};
+	REQUIRE(EntityPhysics::isWallOnRight(pos, PLAYER_SIZE, PLAYER_SIZE, world));
+}
+
+TEST_CASE("isWallOnRight: returns false when nothing to the right")
+{
+	World world = makeEmptyWorld();
+	sf::Vector2f pos{5 * T, WALL_TOP + T / 2.f};
+	REQUIRE(!EntityPhysics::isWallOnRight(pos, PLAYER_SIZE, PLAYER_SIZE, world));
+}
+
+// ─── applyGravity ─────────────────────────────────────────────────────────────
+
+TEST_CASE("applyGravity: accelerates downward when no ground below")
+{
+	World world = makeEmptyWorld();
+	float velY = 0.f;
+	bool isOnGround = false;
+	sf::FloatRect bounds({WALL_LEFT, WALL_TOP}, {PLAYER_SIZE, PLAYER_SIZE});
+	EntityPhysics::applyGravity(velY, isOnGround, 0.016f, 800.f, bounds, world);
+	REQUIRE(velY > 0.f);
+	REQUIRE(!isOnGround);
+}
+
+TEST_CASE("applyGravity: does not accelerate when ground is directly below")
+{
+	World world = makeWorldWithFloor();
+	float velY = 0.f;
+	bool isOnGround = true;
+	sf::FloatRect bounds({WALL_LEFT, FLOOR_TOP - PLAYER_SIZE}, {PLAYER_SIZE, PLAYER_SIZE});
+	EntityPhysics::applyGravity(velY, isOnGround, 0.016f, 800.f, bounds, world);
+	REQUIRE(velY == 0.f);
+	REQUIRE(isOnGround);
+}
+
+TEST_CASE("applyGravity: sets isOnGround to true when ground is below even if previously false")
+{
+	World world = makeWorldWithFloor();
+	float velY = 0.f;
+	bool isOnGround = false;
+	sf::FloatRect bounds({WALL_LEFT, FLOOR_TOP - PLAYER_SIZE}, {PLAYER_SIZE, PLAYER_SIZE});
+	EntityPhysics::applyGravity(velY, isOnGround, 0.016f, 800.f, bounds, world);
+	REQUIRE(isOnGround);
+	REQUIRE(velY == 0.f);
+}
+
+// ─── resolveHorizontal ────────────────────────────────────────────────────────
+
+TEST_CASE("resolveHorizontal: moves freely when no obstacle")
+{
+	World world = makeEmptyWorld();
+	sf::Vector2f pos{5 * T, WALL_TOP + T / 2.f};
+	float velX = 100.f;
+	float result = EntityPhysics::resolveHorizontal(pos, velX, PLAYER_SIZE, PLAYER_SIZE, 0.016f, world);
+	REQUIRE(result > pos.x);
+	REQUIRE(velX == 100.f);
+}
+
+TEST_CASE("resolveHorizontal: stops and snaps to left of wall on right collision")
+{
+	World world = makeWorldWithWallTile();
+	sf::Vector2f pos{WALL_LEFT - PLAYER_SIZE / 2.f - 4.f, WALL_TOP + T / 2.f};
+	float velX = 500.f;
+	float result = EntityPhysics::resolveHorizontal(pos, velX, PLAYER_SIZE, PLAYER_SIZE, 0.016f, world);
+	REQUIRE(velX == 0.f);
+	REQUIRE(result + PLAYER_SIZE / 2.f < WALL_LEFT);
+}
+
+TEST_CASE("resolveHorizontal: stops and snaps to right of wall on left collision")
+{
+	World world = makeWorldWithWallTile();
+	sf::Vector2f pos{WALL_LEFT + T + PLAYER_SIZE / 2.f + 4.f, WALL_TOP + T / 2.f};
+	float velX = -500.f;
+	float result = EntityPhysics::resolveHorizontal(pos, velX, PLAYER_SIZE, PLAYER_SIZE, 0.016f, world);
+	REQUIRE(velX == 0.f);
+	REQUIRE(result - PLAYER_SIZE / 2.f >= WALL_LEFT + T);
+}
+
+// ─── resolveVertical ──────────────────────────────────────────────────────────
+
+TEST_CASE("resolveVertical: falls freely when no ground")
+{
+	World world = makeEmptyWorld();
+	sf::Vector2f pos{5 * T, 2 * T};
+	float velY = 200.f;
+	bool isOnGround = false;
+	float result = EntityPhysics::resolveVertical(pos, velY, isOnGround, PLAYER_SIZE, PLAYER_SIZE, 0.016f, world);
+	REQUIRE(result > pos.y);
+	REQUIRE(velY == 200.f);
+	REQUIRE(!isOnGround);
+}
+
+TEST_CASE("resolveVertical: landing sets isOnGround and snaps feet to floor surface")
+{
+	World world = makeWorldWithFloor();
+	sf::Vector2f pos{WALL_LEFT, FLOOR_TOP - 1.f};
+	float velY = 500.f;
+	bool isOnGround = false;
+	float result = EntityPhysics::resolveVertical(pos, velY, isOnGround, PLAYER_SIZE, PLAYER_SIZE, 0.016f, world);
+	REQUIRE(isOnGround);
+	REQUIRE(result == FLOOR_TOP);
+	REQUIRE(velY == 0.f);
+}
+
+TEST_CASE("resolveVertical: head collision snaps below ceiling and zeros upward velocity")
+{
+	World world = makeWorldWithFloor();
+	sf::Vector2f pos{WALL_LEFT, FLOOR_TOP + PLAYER_SIZE + 2.f};
+	float velY = -500.f;
+	bool isOnGround = false;
+	float result = EntityPhysics::resolveVertical(pos, velY, isOnGround, PLAYER_SIZE, PLAYER_SIZE, 0.016f, world);
+	REQUIRE(velY == 0.f);
+	REQUIRE(result == FLOOR_TOP + PLAYER_SIZE);
+}
+
+TEST_CASE("resolveVertical: does not snap player downward at wall-corner top edge")
+{
+	World world = makeWorldWithWallTile();
+	sf::Vector2f pos{WALL_LEFT + T / 2.f, WALL_TOP + 1.f};
+	float velY = -1000.f;
+	bool isOnGround = false;
+	float result = EntityPhysics::resolveVertical(pos, velY, isOnGround, PLAYER_SIZE, PLAYER_SIZE, 0.001f, world);
+	REQUIRE(result == WALL_TOP);
+	REQUIRE(velY == -1000.f);
+	REQUIRE(!isOnGround);
+}
+
+TEST_CASE("resolveVertical: sets isOnGround when stationary player overlaps ground tile")
+{
+	World world = makeWorldWithWallTile();
+	sf::Vector2f pos{WALL_LEFT + T / 2.f, WALL_TOP + PLAYER_SIZE / 2.f};
+	float velY = 0.f;
+	bool isOnGround = false;
+	float result = EntityPhysics::resolveVertical(pos, velY, isOnGround, PLAYER_SIZE, PLAYER_SIZE, 0.016f, world);
+	REQUIRE(isOnGround);
+	REQUIRE(result == WALL_TOP);
+	REQUIRE(velY == 0.f);
+}
+
+// ─── simulateMovement ─────────────────────────────────────────────────────────
+
+TEST_CASE("simulateMovement: entity falls under gravity and lands on floor")
+{
+	World world = makeWorldWithFloor();
+	sf::Vector2f position{WALL_LEFT, T};
+	sf::Vector2f velocity{0.f, 0.f};
+	bool isOnGround = false;
+	EntityPhysics::simulateMovement(0.5f, position, velocity, isOnGround, 800.f, PLAYER_SIZE, PLAYER_SIZE, world);
+	REQUIRE(isOnGround);
+	REQUIRE(position.y == FLOOR_TOP);
+}
+
+TEST_CASE("simulateMovement: entity is blocked horizontally by wall")
+{
+	World world = makeWorldWithWallTile();
+	sf::Vector2f position{WALL_LEFT - PLAYER_SIZE / 2.f - 4.f, WALL_TOP + T / 2.f};
+	sf::Vector2f velocity{1000.f, 0.f};
+	bool isOnGround = false;
+	EntityPhysics::simulateMovement(0.1f, position, velocity, isOnGround, 0.f, PLAYER_SIZE, PLAYER_SIZE, world);
+	REQUIRE(velocity.x == 0.f);
+	REQUIRE(position.x + PLAYER_SIZE / 2.f < WALL_LEFT);
+}
+
+TEST_CASE("simulateMovement: isOnGround recovers to true after being set false externally")
+{
+	World world = makeWorldWithFloor();
+	sf::Vector2f position{WALL_LEFT, FLOOR_TOP};
+	sf::Vector2f velocity{0.f, 0.f};
+	bool isOnGround = false;
+	EntityPhysics::simulateMovement(0.016f, position, velocity, isOnGround, 800.f, PLAYER_SIZE, PLAYER_SIZE, world);
+	REQUIRE(isOnGround);
+	REQUIRE(velocity.y == 0.f);
+}

--- a/tests/unit/player_state_tests.cpp
+++ b/tests/unit/player_state_tests.cpp
@@ -439,6 +439,15 @@ TEST_CASE("WallSlideState transitions")
 		states.wallSlide.onEnter(p);
 		REQUIRE(PlayerTestAccess::getVelocity(p).y < originalVelocity.y);
 	}
+
+	SECTION("transitions to landing when player touches ground")
+	{
+		PlayerTestAccess::setAgainstLeftWall(p, true);
+		states.wallSlide.onEnter(p);
+		PlayerTestAccess::setInputLeft(p, true);
+		PlayerTestAccess::setOnGround(p, true);
+		REQUIRE(states.wallSlide.update(0.1f, p) == &states.landing);
+	}
 }
 
 // ─── Wall slide gating: no gum ────────────────────────────────────────────────


### PR DESCRIPTION
- Bug in vertical/horizontal collision with the two having 1 pixel difference in player bounding box
- Bug in entityphysics not setting isOnGround when 0 vertical velocity and on ground