### PR TITLE
feat: inventory menu refactors

### DIFF
--- a/src/core/input_manager.cpp
+++ b/src/core/input_manager.cpp
@@ -44,11 +44,20 @@ constexpr std::array<GameAction, 7> hotbarSlotActionsArray = {
     GameAction::UseItemSlot1, GameAction::UseItemSlot2, GameAction::UseItemSlot3, GameAction::UseItemSlot4,
     GameAction::UseItemSlot5, GameAction::UseItemSlot6, GameAction::UseItemSlot7,
 };
+constexpr std::array<GameAction, 7> playerActionsArray = {
+    GameAction::MoveLeft, GameAction::MoveRight, GameAction::Jump,        GameAction::Sprint,
+    GameAction::ThrowHat, GameAction::AttackMelee, GameAction::Interact,
+};
 }
 
 std::span<const GameAction> InputManager::hotbarSlotActions() noexcept
 {
 	return hotbarSlotActionsArray;
+}
+
+std::span<const GameAction> InputManager::playerActions() noexcept
+{
+	return playerActionsArray;
 }
 
 bool InputManager::matchesKey(const InputBinding &binding, const sf::Keyboard::Scancode scancode)
@@ -96,6 +105,8 @@ void InputManager::clearFrameState()
 {
 	wasPressed_.fill(false);
 	wasMenuPressed_.fill(false);
+	suppressed_.fill(false);
+	menuSuppressed_.fill(false);
 }
 
 bool InputManager::isHeldBinding(const InputBinding &binding)
@@ -107,23 +118,25 @@ bool InputManager::isHeldBinding(const InputBinding &binding)
 
 bool InputManager::isHeld(const GameAction action) const
 {
+	if (suppressed_[idx(action)])
+		return false;
 	return isHeldBinding(bindings_[idx(action)].primary);
 }
 
 bool InputManager::wasPressed(const GameAction action) const
 {
-	return wasPressed_[idx(action)];
+	return !suppressed_[idx(action)] && wasPressed_[idx(action)];
 }
 
 bool InputManager::wasPressed(const MenuAction action) const
 {
-	return wasMenuPressed_[idx(action)];
+	return !menuSuppressed_[idx(action)] && wasMenuPressed_[idx(action)];
 }
 
 bool InputManager::consume(const GameAction action)
 {
 	bool &flag = wasPressed_[idx(action)];
-	const bool result = flag;
+	const bool result = !suppressed_[idx(action)] && flag;
 	flag = false;
 	return result;
 }
@@ -131,9 +144,21 @@ bool InputManager::consume(const GameAction action)
 bool InputManager::consume(const MenuAction action)
 {
 	bool &flag = wasMenuPressed_[idx(action)];
-	const bool result = flag;
+	const bool result = !menuSuppressed_[idx(action)] && flag;
 	flag = false;
 	return result;
+}
+
+void InputManager::suppress(const GameAction action)
+{
+	suppressed_[idx(action)] = true;
+	wasPressed_[idx(action)] = false;
+}
+
+void InputManager::suppress(const MenuAction action)
+{
+	menuSuppressed_[idx(action)] = true;
+	wasMenuPressed_[idx(action)] = false;
 }
 
 void InputManager::rebind(const GameAction action, InputBinding newBinding)
@@ -169,6 +194,8 @@ void InputManager::resetToDefaults()
 	bindings_ = defaultBindings;
 	wasPressed_.fill(false);
 	wasMenuPressed_.fill(false);
+	suppressed_.fill(false);
+	menuSuppressed_.fill(false);
 }
 
 std::string InputManager::bindingDisplayName(const InputBinding &binding)

--- a/src/core/input_manager.cpp
+++ b/src/core/input_manager.cpp
@@ -45,10 +45,10 @@ constexpr std::array<GameAction, 7> hotbarSlotActionsArray = {
     GameAction::UseItemSlot5, GameAction::UseItemSlot6, GameAction::UseItemSlot7,
 };
 constexpr std::array<GameAction, 7> playerActionsArray = {
-    GameAction::MoveLeft, GameAction::MoveRight, GameAction::Jump,        GameAction::Sprint,
+    GameAction::MoveLeft, GameAction::MoveRight,   GameAction::Jump,     GameAction::Sprint,
     GameAction::ThrowHat, GameAction::AttackMelee, GameAction::Interact,
 };
-}
+} // namespace
 
 std::span<const GameAction> InputManager::hotbarSlotActions() noexcept
 {

--- a/src/core/input_manager.h
+++ b/src/core/input_manager.h
@@ -65,6 +65,10 @@ class InputManager {
 	[[nodiscard]] bool consume(GameAction action);
 	[[nodiscard]] bool consume(MenuAction action);
 
+	/// Silences the action for the rest of this frame: isHeld() and wasPressed() both return false for it.
+	void suppress(GameAction action);
+	void suppress(MenuAction action);
+
 	void rebind(GameAction action, InputBinding newBinding);
 
 	// Returns the action (other than `except`) that already has `binding` as its
@@ -77,6 +81,7 @@ class InputManager {
 	[[nodiscard]] InputBinding getPrimaryBinding(GameAction action) const;
 	[[nodiscard]] static std::span<const ActionMeta> gameActions() noexcept;
 	[[nodiscard]] static std::span<const GameAction> hotbarSlotActions() noexcept;
+	[[nodiscard]] static std::span<const GameAction> playerActions() noexcept;
 
   private:
 	InputManager();
@@ -117,6 +122,8 @@ class InputManager {
 	std::array<Binding, actionCount> bindings_;
 	std::array<bool, actionCount> wasPressed_ = {};
 	std::array<bool, menuActionCount> wasMenuPressed_ = {};
+	std::array<bool, actionCount> suppressed_ = {};
+	std::array<bool, menuActionCount> menuSuppressed_ = {};
 
 	static const std::array<Binding, actionCount> defaultBindings;
 

--- a/src/core/scene_stack.cpp
+++ b/src/core/scene_stack.cpp
@@ -72,7 +72,7 @@ void SceneStack::update(float deltaTime)
 		if (!scenes_[start]->updateBelow())
 			break;
 	}
-	for (std::size_t i = start; i < scenes_.size(); ++i)
+	for (std::size_t i = scenes_.size(); i-- > start;)
 		scenes_[i]->update(deltaTime);
 }
 

--- a/src/scenes/inventory_scene.cpp
+++ b/src/scenes/inventory_scene.cpp
@@ -20,6 +20,10 @@ constexpr sf::Color TEXT_TITLE{240, 240, 240};
 constexpr sf::Color TEXT_BODY{180, 180, 200};
 constexpr sf::Color TEXT_EFFECT{120, 220, 120};
 constexpr float OUTLINE_THICK = 2.f;
+constexpr sf::Color HOTBAR_LABEL_COLOR{180, 180, 200};
+constexpr unsigned int HOTBAR_LABEL_SIZE = 13;
+constexpr float HOTBAR_LABEL_PADDING_X = 4.f;
+constexpr float HOTBAR_LABEL_PADDING_Y = 6.f;
 
 constexpr int PLAYER_FRAME_SIZE = 32;
 } // namespace
@@ -99,8 +103,22 @@ void InventoryScene::handleEvent(const sf::Event &event, sf::RenderWindow &windo
 		if (pressed->button == sf::Mouse::Button::Left) {
 			const sf::Vector2f mousePos = toViewCoords(pressed->position);
 			if (const auto slot = slotAtPoint(mousePos)) {
-				if (inv.hasItem(*slot))
-					drag_ = DragState{*slot, mousePos};
+				if (inv.hasItem(*slot)) {
+					const bool shiftHeld = sf::Keyboard::isKeyPressed(sf::Keyboard::Scancode::LShift)
+					                       || sf::Keyboard::isKeyPressed(sf::Keyboard::Scancode::RShift);
+					if (shiftHeld) {
+						const std::span<const SlotRef> targets =
+						    (slot->kind == SlotKind::Hotbar) ? Inventory::gridSlots() : Inventory::hotbarSlots();
+						for (const SlotRef &target : targets) {
+							if (!inv.hasItem(target)) {
+								inv.moveItem(*slot, target);
+								break;
+							}
+						}
+					} else {
+						drag_ = DragState{*slot, mousePos};
+					}
+				}
 			}
 		}
 	}
@@ -119,6 +137,12 @@ void InventoryScene::handleEvent(const sf::Event &event, sf::RenderWindow &windo
 void InventoryScene::update(const float /*deltaTime*/)
 {
 	InputManager &input = InputManager::getInstance();
+	Inventory &inv = player_.inventory();
+
+	updateItemActions(input, inv);
+
+	for (const GameAction playerAction : InputManager::playerActions())
+		input.suppress(playerAction);
 
 	// Consume both close keys so GameScene::update() never sees them this frame.
 	const bool wantsClose = input.consume(MenuAction::Back) || input.consume(GameAction::OpenInventory);
@@ -129,9 +153,26 @@ void InventoryScene::update(const float /*deltaTime*/)
 			stack_.pop();
 		return;
 	}
+}
+
+void InventoryScene::updateItemActions(InputManager &input, Inventory &inv)
+{
+	// Hotbar slot keys: move the hovered item into the pressed slot, then block the key from GameScene.
+	const std::span<const GameAction> slotActions = InputManager::hotbarSlotActions();
+	for (int i = 0; i < static_cast<int>(slotActions.size()); ++i) {
+		const bool pressed = input.consume(slotActions[i]);
+
+		if (pressed && hovered_ && !drag_) {
+			if (inv.hasItem(*hovered_)) {
+				inv.moveItem(*hovered_, SlotRef{SlotKind::Hotbar, i});
+			} else {
+				inv.moveItem(SlotRef{SlotKind::Hotbar, i}, *hovered_);
+			}
+		}
+	}
 
 	if (input.wasPressed(GameAction::UseItem) && hovered_ && !drag_)
-		player_.inventory().interact(*hovered_, player_);
+		inv.interact(*hovered_, player_);
 }
 
 // --- Drawing ---
@@ -280,6 +321,17 @@ void InventoryScene::drawSlot(sf::RenderTarget &target, const SlotRef slot, cons
 		sprite.setScale({iconSize / static_cast<float>(texSize.x), iconSize / static_cast<float>(texSize.y)});
 		sprite.setPosition({pos.x + 5.f, pos.y + 5.f});
 		target.draw(sprite);
+	}
+
+	if (slot.kind == SlotKind::Hotbar) {
+		const std::string keyName =
+		    InputManager::getInstance().inputName(InputManager::hotbarSlotActions()[slot.index]);
+		sf::Text label(AssetManager::getInstance().getFont(UI_FONT), keyName, HOTBAR_LABEL_SIZE);
+		label.setFillColor(HOTBAR_LABEL_COLOR);
+		const sf::FloatRect textBounds = label.getLocalBounds();
+		label.setPosition({pos.x + SLOT_SIZE - textBounds.size.x - HOTBAR_LABEL_PADDING_X,
+		                   pos.y + SLOT_SIZE - textBounds.size.y - HOTBAR_LABEL_PADDING_Y});
+		target.draw(label);
 	}
 }
 

--- a/src/scenes/inventory_scene.h
+++ b/src/scenes/inventory_scene.h
@@ -8,6 +8,7 @@
 #include <optional>
 #include <vector>
 
+class InputManager;
 class Player;
 
 class InventoryScene : public Scene {
@@ -19,7 +20,7 @@ class InventoryScene : public Scene {
 	void draw(sf::RenderWindow &window) override;
 
 	[[nodiscard]] bool isTransparent() const override { return true; }
-	[[nodiscard]] bool updateBelow() const override { return false; }
+	[[nodiscard]] bool updateBelow() const override { return true; }
 
   private:
 	struct DragState {
@@ -31,6 +32,8 @@ class InventoryScene : public Scene {
 	[[nodiscard]] sf::Vector2f slotScreenPos(SlotRef slot) const noexcept;
 	[[nodiscard]] sf::FloatRect slotBounds(SlotRef slot) const noexcept;
 	[[nodiscard]] std::optional<SlotRef> slotAtPoint(sf::Vector2f point) const noexcept;
+
+	void updateItemActions(InputManager &input, Inventory &inv);
 
 	void drawBackground(sf::RenderTarget &target) const;
 	void drawPlayerPreview(sf::RenderTarget &target) const;

--- a/tests/unit/input_manager_tests.cpp
+++ b/tests/unit/input_manager_tests.cpp
@@ -188,3 +188,88 @@ TEST_CASE("InputManager - hotbarSlotActions size matches HOTBAR_SIZE")
 {
 	CHECK(InputManager::hotbarSlotActions().size() == static_cast<std::size_t>(Inventory::HOTBAR_SIZE));
 }
+
+// ─── suppress ────────────────────────────────────────────────────────────────
+
+TEST_CASE("InputManager - suppress(GameAction) makes wasPressed return false")
+{
+	auto &im = InputManager::getInstance();
+	im.resetToDefaults();
+
+	im.handleEvent(keyPressed(sf::Keyboard::Scancode::Space));
+	im.suppress(GameAction::Jump);
+
+	CHECK_FALSE(im.wasPressed(GameAction::Jump));
+}
+
+TEST_CASE("InputManager - suppress(GameAction) makes consume return false")
+{
+	auto &im = InputManager::getInstance();
+	im.resetToDefaults();
+
+	im.handleEvent(keyPressed(sf::Keyboard::Scancode::Space));
+	im.suppress(GameAction::Jump);
+
+	CHECK_FALSE(im.consume(GameAction::Jump));
+}
+
+TEST_CASE("InputManager - suppress(GameAction) does not affect other actions")
+{
+	auto &im = InputManager::getInstance();
+	im.resetToDefaults();
+
+	im.handleEvent(keyPressed(sf::Keyboard::Scancode::Space));
+	im.handleEvent(keyPressed(sf::Keyboard::Scancode::A));
+	im.suppress(GameAction::Jump);
+
+	CHECK_FALSE(im.wasPressed(GameAction::Jump));
+	CHECK(im.wasPressed(GameAction::MoveLeft));
+}
+
+TEST_CASE("InputManager - suppress(GameAction) is cleared by clearFrameState")
+{
+	auto &im = InputManager::getInstance();
+	im.resetToDefaults();
+
+	im.handleEvent(keyPressed(sf::Keyboard::Scancode::Space));
+	im.suppress(GameAction::Jump);
+	im.clearFrameState();
+	im.handleEvent(keyPressed(sf::Keyboard::Scancode::Space));
+
+	CHECK(im.wasPressed(GameAction::Jump));
+}
+
+TEST_CASE("InputManager - suppress(MenuAction) makes wasPressed return false")
+{
+	auto &im = InputManager::getInstance();
+	im.resetToDefaults();
+
+	im.handleEvent(keyPressed(sf::Keyboard::Scancode::Escape));
+	im.suppress(MenuAction::Back);
+
+	CHECK_FALSE(im.wasPressed(MenuAction::Back));
+}
+
+TEST_CASE("InputManager - suppress(MenuAction) makes consume return false")
+{
+	auto &im = InputManager::getInstance();
+	im.resetToDefaults();
+
+	im.handleEvent(keyPressed(sf::Keyboard::Scancode::Escape));
+	im.suppress(MenuAction::Back);
+
+	CHECK_FALSE(im.consume(MenuAction::Back));
+}
+
+TEST_CASE("InputManager - suppress(MenuAction) is cleared by clearFrameState")
+{
+	auto &im = InputManager::getInstance();
+	im.resetToDefaults();
+
+	im.handleEvent(keyPressed(sf::Keyboard::Scancode::Escape));
+	im.suppress(MenuAction::Back);
+	im.clearFrameState();
+	im.handleEvent(keyPressed(sf::Keyboard::Scancode::Escape));
+
+	CHECK(im.wasPressed(MenuAction::Back));
+}


### PR DESCRIPTION
- remove game pause during inventory menu
- add shortcuts for moving inventory objects
   - Shift + Click swaps between inventory and hotbar
   - Pressing hotbar keys while hovering items moves items to hotbar slot and pressing hotbar key on empty slot moves hotbar item to inventory

closes #30 